### PR TITLE
Update RegistersAddCard.vue to use well-known-uri

### DIFF
--- a/src/components/registers/RegistersAddCard.vue
+++ b/src/components/registers/RegistersAddCard.vue
@@ -13,11 +13,16 @@ const status = ref<Status>({
 const addRegisters = async () => {
 	status.value.type = "loading";
 
-	// If the url doesn't have a protocol, add the https protocol
-	if(!url.value.startsWith("https://")) url.value = "https://" + url.value
+	// If the url can't be parsed, and doesn't begin with https, 
+	// assume the default and add the https protocol
+	if(!URL.canParse(url.value) && !url.value.startsWith("https://")){
+		url.value = "https://" + url.value
+	} 
 
 	// If the url doesn't end in .json, assume the metadata is in the well known location.
-	if(!url.value.endsWith(".json")) url.value = url.value + "/.well-known/bitcoin-cash-metadata-registry.json"
+	if(!url.value.endsWith(".json")) {
+		url.value = url.value + "/.well-known/bitcoin-cash-metadata-registry.json"
+	}
 
 	const result = await registryStore.addRegistryProvider(url.value);
 	status.value = {


### PR DESCRIPTION
- Prepend new registries with "https://", if not provided.
- If a url doesn't end in json, assume it follows the well-known URI for BCMR.
- Add trigger on "keyup.enter" for input.

see: 
https://cashtokens.org/docs/bcmr/chip#well-known-uri

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced URL validation for adding registers: ensures URLs start with "https://" and end with the appropriate JSON endpoint.
	- Added functionality to trigger the addition of registers by pressing the Enter key.

These improvements streamline the user experience when adding registry providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->